### PR TITLE
Make `ermittlungsauftrag.flatId` and `prozess.einheit` nullable

### DIFF
--- a/src/bssclient/models/ermittlungsauftrag.py
+++ b/src/bssclient/models/ermittlungsauftrag.py
@@ -29,7 +29,7 @@ class Ermittlungsauftrag(BaseModel):
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
     id: UUID
-    flat_id: str = Field(alias="flatId")
+    flat_id: str | None = Field(alias="flatId", default=None)
     """
     the external ID of the respective Wohneinheit
     """

--- a/src/bssclient/models/prozess.py
+++ b/src/bssclient/models/prozess.py
@@ -23,6 +23,6 @@ class Prozess(BaseModel):
     transaktionsgrund: str
     ausloeser_daten: str = Field(alias="ausloeserDaten")
     antwort_status: str = Field(alias="antwortStatus")
-    einheit: str
+    einheit: str | None = None
     messlokation: str
     zaehlernummer: str


### PR DESCRIPTION
Fixes
> 0.flatId
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
0.prozess.einheit
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
8.flatId
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type