### PR TITLE
fix: let `model_validator` return `self`

### DIFF
--- a/src/bssclient/client/config.py
+++ b/src/bssclient/client/config.py
@@ -1,6 +1,7 @@
 """
 contains a class with which the BSS client is instantiated/configured
 """
+
 from typing import Self
 
 from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator, model_validator
@@ -88,17 +89,17 @@ class OAuthBssConfig(BssConfig):
     This is useful when you have ways to get a token but not a client id and secret.
     """
 
-    @model_validator(mode="after")  # type:ignore[misc, no-untyped-def]
+    @model_validator(mode="after")
     def check_secret_or_token_is_present(self) -> Self:
         """
         Ensures that either (id+secret) or a bare token are present
         """
         token_is_present = self.bearer_token is not None and self.bearer_token.strip()
         client_id_and_secret_are_present = (
-                self.client_id is not None
-                and self.client_id.strip()
-                and self.client_secret is not None
-                and self.client_secret.strip()
+            self.client_id is not None
+            and self.client_id.strip()
+            and self.client_secret is not None
+            and self.client_secret.strip()
         )
         if not token_is_present and not client_id_and_secret_are_present:
             raise ValueError(


### PR DESCRIPTION
UserWarning: A custom validator is returning a value other than self.
Returning anything other than self from a top level model validator isn't supported when validating via __init__.
See the model_validator docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.
